### PR TITLE
Support back to jQuery 1.3

### DIFF
--- a/jquery.rwdImageMaps.js
+++ b/jquery.rwdImageMaps.js
@@ -8,13 +8,17 @@
 * Licensed under the MIT license
 */
 (function($) {
+	var w, h;
 	$.fn.rwdImageMaps = function() {
 		var $img = this;
 		var rwdImageMap = function() {
 			$img.each(function() {
 				if (typeof($(this).attr('usemap')) == 'undefined')
 					return;
-				var w = $(this).attr('width'), h = $(this).attr('height'), wPercent = $(this).width()/100, hPercent = $(this).height()/100, map = $(this).attr('usemap').replace('#', ''), c = 'coords';
+				var wPercent = $(this).width()/100, hPercent = $(this).height()/100, map = $(this).attr('usemap').replace('#', ''), c = 'coords';
+				if (w == undefined) {
+					w = $img.attr('width'), h = $img.attr('height');
+				}
 				$('map[name="' + map + '"]').find('area').each(function() {
 					if (!$(this).data(c))
 						$(this).data(c, $(this).attr(c));


### PR DESCRIPTION
I've a site that needs to use this, but can't for other reasons, upgrade to 1.7. It looks like the reason it was failing in 1.3 was because the width and height values were resetting with each resize. That threw the math off for calculating the coordinates. So I've moved the width and height variables out of scope for the resize, and added a check to see if they've already been set - if so leave them alone.

I tested this against jQuery 1.3.2, and 1.7 and both seemed to work well. Let me know if I've overlooked anything or if your testing indicates otherwise.

I'm not sure which tool you used to minimize, so I left the min file alone.
