### PR TITLE
If width/height attrib is undefined use the original size

### DIFF
--- a/jquery.rwdImageMaps.js
+++ b/jquery.rwdImageMaps.js
@@ -34,6 +34,16 @@
 						w = $that.attr(attrW),
 						h = $that.attr(attrH);	
 					
+					if (typeof(w) == 'undefined' || typeof(h) == 'undefined') {
+						// get original image size by creating a temporary copy
+						var t = new Image();
+						t.src = $that.attr("src");
+						if (typeof(w) == 'undefined')
+							w = t.width;
+						if (typeof(h) == 'undefined')
+							h = t.height;
+					}
+
 					var wPercent = $that.width()/100,
 						hPercent = $that.height()/100,
 						map = $that.attr('usemap').replace('#', ''),

--- a/jquery.rwdImageMaps.min.js
+++ b/jquery.rwdImageMaps.min.js
@@ -1,11 +1,1 @@
-/*
-* rwdImageMaps jQuery plugin v1.3
-*
-* Allows image maps to be used in a responsive design by recalculating the area coordinates to match the actual image size on load and window.resize
-*
-* Copyright (c) 2012 Matt Stow
-* https://github.com/stowball/jQuery-rwdImageMaps
-* http://mattstow.com
-* Licensed under the MIT license
-*/
-;(function(a){a.fn.rwdImageMaps=function(){var d=this,c=parseFloat(a.fn.jquery);var b=function(){d.each(function(){if(typeof(a(this).attr("usemap"))=="undefined"){return}var f=this,e=a(f);a("<img />").load(function(){var i,k,l="width",g="height";if(c<1.6){i=f.getAttribute(l),k=f.getAttribute(g)}else{i=e.attr(l),k=e.attr(g)}var j=e.width()/100,n=e.height()/100,m=e.attr("usemap").replace("#",""),o="coords";a('map[name="'+m+'"]').find("area").each(function(){var r=a(this);if(!r.data(o)){r.data(o,r.attr(o))}var q=r.data(o).split(","),p=new Array(q.length);for(var h=0;h<p.length;++h){if(h%2===0){p[h]=parseInt(((q[h]/i)*100)*j)}else{p[h]=parseInt(((q[h]/k)*100)*n)}}r.attr(o,p.toString())})}).attr("src",e.attr("src"))})};a(window).resize(b).trigger("resize");return this}})(jQuery);
+(function(a){a.fn.rwdImageMaps=function(){var d=this,c=parseFloat(a.fn.jquery);var b=function(){d.each(function(){if(typeof(a(this).attr("usemap"))=="undefined"){return}var f=this,e=a(f);a("<img />").load(function(){var o,k,i="width",n="height";if(c<1.6){o=f.getAttribute(i),k=f.getAttribute(n)}else{o=e.attr(i),k=e.attr(n)}if(typeof(o)=="undefined"||typeof(k)=="undefined"){var p=new Image();p.src=e.attr("src");if(typeof(o)=="undefined"){o=p.width}if(typeof(k)=="undefined"){k=p.height}}var g=e.width()/100,l=e.height()/100,j=e.attr("usemap").replace("#",""),m="coords";a('map[name="'+j+'"]').find("area").each(function(){var s=a(this);if(!s.data(m)){s.data(m,s.attr(m))}var r=s.data(m).split(","),q=new Array(r.length);for(var h=0;h<q.length;++h){if(h%2===0){q[h]=parseInt(((r[h]/o)*100)*g)}else{q[h]=parseInt(((r[h]/k)*100)*l)}}s.attr(m,q.toString())})}).attr("src",e.attr("src"))})};a(window).resize(b).trigger("resize");return this}})(jQuery);


### PR DESCRIPTION
With width:100% (in CSS) for the image used for the map you usually do
not want to set width and height properties of the IMG tag.

In this case rwdImageMaps should use the size of the image itself.
